### PR TITLE
broker: Add binding for redis

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -477,6 +477,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "10d491fa357f6c2c3c8ebf0338b533941381a5f2c922c2279e80efac37efc161"
+  inputs-digest = "616a159e557c42812fdcdbc3eabf57bf40d77a98a6c5cc3d13a27c1022ed9e4b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/manifests/redis/binding.yaml
+++ b/manifests/redis/binding.yaml
@@ -1,0 +1,8 @@
+apiVersion: servicecatalog.k8s.io/v1beta1
+kind: ServiceBinding
+metadata:
+  name: redis-binding
+  namespace: default
+spec:
+  instanceRef:
+    name: redis-habitat

--- a/pkg/broker/random.go
+++ b/pkg/broker/random.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2018 Chef Software Inc. and/or applicable contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package broker
+
+import (
+	"math/rand"
+	"time"
+)
+
+// Inspired from: https://stackoverflow.com/a/22892986/1773961
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyz1234567890")
+
+func init() {
+	rand.Seed(time.Now().Unix())
+}
+
+func randSeq(n int) string {
+	buffer := make([]rune, n)
+	for i := range buffer {
+		buffer[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(buffer)
+}

--- a/pkg/broker/services.go
+++ b/pkg/broker/services.go
@@ -76,7 +76,7 @@ func redisService() osb.Service {
 		Name:          "redis-habitat",
 		ID:            "50e86479-4c66-4236-88fb-a1e61b4c9448",
 		Description:   "Redis packaged with Habitat",
-		Bindable:      false,
+		Bindable:      true,
 		PlanUpdatable: boolPtr(false),
 		Metadata: map[string]interface{}{
 			"displayName": "Habitat Redis service",

--- a/pkg/broker/utils.go
+++ b/pkg/broker/utils.go
@@ -19,6 +19,22 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func (b *BrokerLogic) GetHabitat(name string) (*habv1beta1.Habitat, error) {
+	result := &habv1beta1.Habitat{}
+	err := b.KubeClient.Client.Get().
+		Namespace("default"). // TODO: figure out how to know in which namespace to deploy.
+		Resource(habv1beta1.HabitatResourcePlural).
+		Name(name).
+		Do().
+		Into(result)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // CreateHabitat creates a Habitat resource through the Kuberentes client,
 // based on the passed Habitat object.
 func (b *BrokerLogic) CreateHabitat(habitat *habv1beta1.Habitat) error {
@@ -26,6 +42,16 @@ func (b *BrokerLogic) CreateHabitat(habitat *habv1beta1.Habitat) error {
 	return b.KubeClient.Client.Post().
 		Namespace("default"). // TODO: figure out how to know in which namespace to deploy.
 		Resource(habv1beta1.HabitatResourcePlural).
+		Body(habitat).
+		Do().
+		Error()
+}
+
+func (b *BrokerLogic) UpdateHabitat(habitat *habv1beta1.Habitat) error {
+	return b.KubeClient.Client.Put().
+		Namespace("default"). // TODO: figure out how to know in which namespace to deploy.
+		Resource(habv1beta1.HabitatResourcePlural).
+		Name(habitat.Name).
 		Body(habitat).
 		Do().
 		Error()
@@ -47,6 +73,7 @@ func NewHabitat(name, image string, count int) *habv1beta1.Habitat {
 			Service: habv1beta1.Service{
 				Group:    "default",
 				Topology: habv1beta1.TopologyStandalone,
+				Name:     name, // This should always be the habitat package name
 			},
 		},
 	}


### PR DESCRIPTION
### Steps to test

**Set up the cluster**
```
minikube start --kubernetes-version v1.9.4 --extra-config=apiserver.Authorization.Mode=RBAC
eval $(minikube docker-env)
sleep 5

kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/scripts/minikube-rbac.yaml

helm init

sleep 10

kubectl create clusterrolebinding tiller-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default

helm repo add svc-cat https://svc-catalog-charts.storage.googleapis.com

sleep 30

helm install svc-cat/catalog --name catalog --namespace catalog
```

Run `kubectl get pods --all-namespaces` and wait until all pods are running.

**Deploy habitat operator**

From the habitat-operator project root:

```
git fetch && git checkout master
make image
kubectl apply -f examples/rbac/
```

Check and wait for the habitat operator to be in `Running` state.


**Install the habitat service broker**

```
make deploy-helm
kubectl apply -f https://gist.githubusercontent.com/indradhanush/f8e79c5097370afd7f75d50f0b65a840/raw/33c6340bf2d50b53cc81aad92969622f6f08fc96/habitat-osb-hack.yml
```

See issue #10 for more details on the above hack.

Wait for pod to be in `Running` state.

**Install svcat**

Follow this link for more details: https://github.com/kubernetes-incubator/service-catalog/blob/master/docs/install.md#installing-the-service-catalog-cli

**Check status of the broker**

```
$ svcat get brokers
       NAME                                                 URL                                            STATUS  
+----------------+---------------------------------------------------------------------------------------+--------+
habitat-broker   http://habitat-service-broker-habitat-service-broker.habitat-broker.svc.cluster.local   Ready
```

**Check status of installed service classes**

```
$ svcat get classes
      NAME                DESCRIPTION                           UUID                  
+---------------+-----------------------------+--------------------------------------+
  nginx-habitat   Nginx packaged with Habitat   1ac7de1d-d89a-41c7-b9a8-744f9256e375  
  redis-habitat   Redis packaged with Habitat   50e86479-4c66-4236-88fb-a1e61b4c9448  
```

**Install the redis service binding**

```
kubectl apply -f manifests/redis/service-instance.yaml

svcat get instances
```

Check status of pod created in the `default` namespace. Play around.

**Install the binding**

```
kubectl apply -f manifests/redis/binding.yaml

svcat get bindings
```

```
kubectl get secrets habitat-osb-binding -o yaml
```

Look for the value under the `data` segment for the key
`user.toml`. It will look something like this:

```
...
data:
  user.toml: cmVxdWlyZXBhc3MgPSAibWNiREllYzY0MCI=
...
```

The string contains the base64 encoded password. For example, you
can use the following to retrieve it for the above string:

echo "cmVxdWlyZXBhc3MgPSAibWNiREllYzY0MCI=" | base64 -d


**Test the bindings**

```
kubectl exec redis-0 -ti bash

$ redis-cli
> auth <insert-password-here>
```

Note: Currently to see the changes reflected correctly the pod
needs to be deleted by running `kubectl delete pods redis-0` and
the new pod that is spawned will have the changes. However this
is far from ideal behaviour and is an independent issue
probably. This is a workaround at the moment but you're welcome
to test it without deleting the pod first. :)
