### PR TITLE
Change command to apply to allow updating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ deploy-helm: image
 	--set image="$(IMAGE):$(TAG)",imagePullPolicy="$(PULL)"
 
 provision-redis:
-	kubectl create -f manifests/redis/
+	kubectl apply -f manifests/redis/
 
 provision-nginx:
-	kubectl create -f manifests/nginx/
+	kubectl apply -f manifests/nginx/
 
 deprovision-redis:
 	kubectl delete -f manifests/redis


### PR DESCRIPTION
With create, you cannot do another create on the already existing object. This will enable to update the manifest file, and is one step towards the Update request being handled correctly.