### PR TITLE
manifests: Create redis service in namespace

### DIFF
--- a/manifests/redis/service.yaml
+++ b/manifests/redis/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis-service
+  namespace: redis-habitat
 spec:
   selector:
     habitat-name: redis


### PR DESCRIPTION
To expose the pod in a custom namespace, the service also needs to be
created in that namespace. The manifest stopped working after we added
support for custom namespaces earlier.